### PR TITLE
fix(auth): corregir redirección en /editar-perfil con onAuthStateChanged

### DIFF
--- a/src/app/apuntes/page.tsx
+++ b/src/app/apuntes/page.tsx
@@ -82,7 +82,7 @@ export default function Apuntes() {
           <div className="flex justify-start">
             <Link
               href="/create-note"
-              className="mb-4 px-4 py-2 bg-duoc-yellow text-duoc-blue font-semibold rounded-lg shadow-md hover:bg-duoc-blue hover:text-white transition cursor-pointer"
+              className="mb-4 px-4 py-2 bg-duoc-yellow text-duoc-blue font-semibold rounded-lg shadow-md hover:bg-duoc-blue hover:!text-white transition cursor-pointer"
             >
               Publicar nuevo apunte
             </Link>

--- a/src/app/create-note/page.tsx
+++ b/src/app/create-note/page.tsx
@@ -79,10 +79,7 @@ export default function CreateNote() {
     try {
       setSubmitting(true);
 
-      // Definir "cuerpo" según el tipo:
-      // - text: contenido de texto
-      // - link: URL
-      // - media/document: URL subida a Storage
+
       let cuerpo = "";
 
       if (activeTab === "text") {

--- a/src/app/editar-perfil/page.tsx
+++ b/src/app/editar-perfil/page.tsx
@@ -1,9 +1,10 @@
-
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import BackButton from "@/components/BackButton";
+import { onAuthStateChanged } from "firebase/auth";
+import { auth } from "@/lib/firebase";
 
 type User = {
     firstName?: string;
@@ -37,33 +38,33 @@ export default function EditarPerfilPage() {
     const router = useRouter();
 
     useEffect(() => {
-        // Se intenta leer el usuario almacenado localmente y se precargan los campos del formulario
-        try {
-            const raw = localStorage.getItem("duocUser");
-            const u: User | null = raw ? JSON.parse(raw) : null;
-
-            if (!u) {
-                // En ausencia de usuario, se redirige al login para mantener consistencia de flujo
+        setLoading(true);
+        const unsub = onAuthStateChanged(auth, (user) => {
+            if (user) {
+                // Usuario autenticado: precargar datos si existen en localStorage
+                setEmail(user.email ?? "");
+                try {
+                    const raw = localStorage.getItem("duocUser");
+                    const u: User | null = raw ? JSON.parse(raw) : null;
+                    setForm({
+                        firstName: u?.firstName ?? "",
+                        lastName: u?.lastName ?? "",
+                        school: u?.school ?? "",
+                    });
+                    setAvatarUrl(u?.avatarUrl ?? "");
+                } catch {
+                    setForm({ firstName: "", lastName: "", school: "" });
+                    setAvatarUrl("");
+                } finally {
+                    setLoading(false);
+                }
+            } else {
+                // No autenticado -> redirigir a login
+                setLoading(false);
                 router.replace("/login?next=/editar-perfil");
-                return;
             }
-
-            setForm({
-                firstName: u.firstName ?? "",
-                lastName: u.lastName ?? "",
-                school: u.school ?? "",
-            });
-
-            setAvatarUrl(u.avatarUrl ?? "");
-            setEmail(u.email ?? "");
-        } catch {
-            // En caso de error de parseo, se limpia el estado
-            setForm({ firstName: "", lastName: "", school: "" });
-            setAvatarUrl("");
-            setEmail("");
-        } finally {
-            setLoading(false);
-        }
+        });
+        return () => unsub();
     }, [router]);
 
     // Iniciales derivadas del nombre/apellido o del correo como respaldo
@@ -110,6 +111,9 @@ export default function EditarPerfilPage() {
 
             // Se persiste el usuario actualizado en localStorage
             localStorage.setItem("duocUser", JSON.stringify(updated));
+
+            // Notifica a otros componentes (Navbar) en la misma pestaña
+            window.dispatchEvent(new CustomEvent("duocUser:updated", { detail: updated }));
 
             setSaved(true);
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -44,6 +44,32 @@ export default function Navbar() {
     return () => unsub();
   }, []);
 
+  // Escucha actualizaciones del perfil guardadas en Editar Perfil
+  useEffect(() => {
+    const onUpdated = (e: Event) => {
+      const detail = (e as CustomEvent<User>).detail;
+      if (!detail) return;
+      setUser((prev) => ({ ...(prev ?? {}), ...detail }));
+    };
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === "duocUser") {
+        try {
+          const next = e.newValue ? JSON.parse(e.newValue) : null;
+          if (next) setUser((prev) => ({ ...(prev ?? {}), ...next }));
+        } catch {
+          /* noop */
+        }
+      }
+    };
+
+    window.addEventListener("duocUser:updated", onUpdated as EventListener);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener("duocUser:updated", onUpdated as EventListener);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
   const handleLogout = async () => {
     await signOut(auth);
     router.push("/login");
@@ -51,7 +77,7 @@ export default function Navbar() {
 
   // Genera iniciales si no hay imagen de perfil
   const initials =
-    (user?.firstName?.[0] ?? "") + (user?.lastName?.[0] ?? "") || "DU";
+    (user?.firstName?.[0] ?? "") + (user?.lastName?.[0] ?? "") || "CM";
 
   return (
     <nav className="fixed top-0 left-0 w-full bg-duoc-blue text-white shadow-md z-50">
@@ -73,9 +99,6 @@ export default function Navbar() {
           <Link href="/viajes" className="hover:text-duoc-yellow">
             Viajes
           </Link>
-          <Link href="/perfil" className="hover:text-duoc-yellow">
-            Perfil
-          </Link>
           <Link href="/home#tutoring" className="hover:text-duoc-yellow">
             Ayudantías
           </Link>
@@ -84,6 +107,14 @@ export default function Navbar() {
             <div className="flex items-center gap-4 ml-4">
               {/* Campanita de notificaciones */}
               <NotificationsBell />
+
+              {/* Botón Perfil (nuevo) */}
+              <Link
+                href="/perfil"
+                className="px-3 py-1 rounded-lg border-2 border-duoc-yellow text-duoc-yellow font-semibold hover:bg-duoc-yellow hover:text-duoc-blue transition"
+              >
+                Perfil
+              </Link>
 
               {/* Imagen de perfil o iniciales */}
               <div className="w-10 h-10 rounded-full overflow-hidden border-2 border-duoc-yellow bg-white flex items-center justify-center text-duoc-blue font-semibold">


### PR DESCRIPTION
## Descripción
Corrección del bug de redirección en “Editar perfil” y mejoras en el Navbar:
- fix(auth): en /editar-perfil se usa onAuthStateChanged (Firebase Auth) para decidir redirección; evita enviar al login cuando hay sesión válida.
- feat(navbar): agrega botón “Perfil” entre la campana y el avatar.
- sync(navbar): sincroniza el avatar con la URL ingresada en “Editar perfil” usando:
  - Persistencia en localStorage (clave: duocUser).
  - Evento global window "duocUser:updated" y escucha de "storage" para refresco en tiempo real.

## Tipo de cambio
- [x] Arreglo
- [x] Función
- [ ] Refactorización
- [ ] Documentación
- [ ] Pruebas

## Cómo probar
1) Redirección editar-perfil:
   - Sin sesión: navegar a /editar-perfil → redirige a /login?next=/editar-perfil.
   - Con sesión activa: abrir /editar-perfil → permanece en la página sin redirigir.
2) Navbar:
   - Ver en desktop el botón “Perfil” entre la campana y la imagen de perfil, navegando a /perfil.
   - En “Editar perfil”, cambiar la URL del avatar y guardar:
     - El avatar del Navbar debe actualizarse inmediatamente (sin refrescar).
     - Refrescar la página y verificar que persiste (localStorage: duocUser).
   - Si no hay avatar, se muestran iniciales derivadas de nombre y apellido.
3) Validaciones:
   - npx next lint
   - npx tsc --noEmit
   - npm run build

## Checklist
- [x] Redirección basada en estado real de Firebase Auth.
- [x] Botón “Perfil” visible y ubicado entre campana y avatar.
- [x] Sincronización de avatar vía "duocUser:updated" y evento "storage".
- [x] Lint/TS y build pasan localmente.

## Referencias
Closes #15
